### PR TITLE
Fix comment in scale_vector python script to show we're scaling vectors, not adding them.

### DIFF
--- a/week1/linear-maps/python.tex
+++ b/week1/linear-maps/python.tex
@@ -64,7 +64,7 @@ Next, write a scalar multiplication function.
 		
 def scale_vector(alpha, v):
   # your code here
-  return # the sum v+w
+  return # the scaled vector alpha * v
 
 def validator():
   # It would be better to try more cases


### PR DESCRIPTION
There was a typo in the Python template; scale_vector doesn't add any vectors.
