### PR TITLE
Fixed typo in vector formulation of cosine rule

### DIFF
--- a/week1/inner-product/angle.tex
+++ b/week1/inner-product/angle.tex
@@ -51,7 +51,7 @@ We can rephrase this in terms of vectors, since geometrically if $\vec{v}$ and $
 %BADBAD PICTURE
 
 \begin{theorem}
-  For any two vectors $v,w \in \R^n$, $|w-v|^2 = |w|^2 +|v^2| - 2|v| |w| \cos(\theta) $, where $\theta$ is the angle between $v$ and $w$.
+  For any two vectors $v,w \in \R^n$, $|w-v|^2 = |w|^2 +|v|^2 - 2|v| |w| \cos(\theta) $, where $\theta$ is the angle between $v$ and $w$.
 \end{theorem}
 
 (For you sticklers, this is really being taken as the \textit{definition} of the angle between two vectors in arbitrary dimension.)


### PR DESCRIPTION
Fixed type on line 54, changing |v^2| to |v|^2
