### PR TITLE
Update linear-maps.tex

### DIFF
--- a/week1/linear-maps.tex
+++ b/week1/linear-maps.tex
@@ -489,7 +489,7 @@ We begin by defining linear maps.
   any $\vec{v} \in \R^n$.
   \begin{free-response}
     I want to determine what $L$ does to any vector $\vec{v} = \verticalvector{x_1\\x_2\\x_3\\.\\.\\.\\x_n} \in \R^n$.  
-    I can rewrite $\vec{v}$ as $x_1\vec{e_1}+x_2\vec{e_2}+x_3\vec{e_3}+...+\x_n\vec{e_n}$.  By the linearity of $L$,
+    I can rewrite $\vec{v}$ as $x_1\vec{e_1}+x_2\vec{e_2}+x_3\vec{e_3}+...+x_n\vec{e_n}$.  By the linearity of $L$,
     $L(\vec{v}) = x_1L(\vec{e_1})+x_2L(\vec{e_2})+x_3L(\vec{e_3})+...+x_nL(\vec{e_n})$.  Since I already know the value of 
     $L(\vec{e_i})$ for all $i=1,2,3,...,n$, this allows me to compute $L(\vec{v})$.  So $L$ is completely determined once I know what it does to each of the
     standard basis vectors. 


### PR DESCRIPTION
no need for a \ in front of the last x in: I can rewrite $\vec{v}$ as $x_1\vec{e_1}+x_2\vec{e_2}+x_3\vec{e_3}+...+\x_n\vec{e_n}$
