### PR TITLE
Replace incorrectly rendering Latex with \texttt{..}

### DIFF
--- a/week1/functions/python/higher-order.tex
+++ b/week1/functions/python/higher-order.tex
@@ -36,7 +36,7 @@ def validator():
 
   \begin{solution}
     Write a function \verb|forward_difference| which takes a function $f : \R \to \R$ and returns another real-valued function defined 
-    by $\text{\verb|forward_difference|}(f)(x) = f(x+1)-f(x)$.
+    by $\texttt{forward_difference}(f)(x) = f(x+1)-f(x)$.
 
     \begin{python}
 def forward_difference(f):


### PR DESCRIPTION
There were a couple complaints in the comments about this line. I'm assuming the intent in placing verbatim text within a text macro was for teletype-text, so I've replaced \text{\verb|...|} with \texttt{...}.
