### PR TITLE
Fix typos in week1 activities

### DIFF
--- a/week1/Rn.tex
+++ b/week1/Rn.tex
@@ -12,7 +12,7 @@ In this course we will be studying calculus of many variables.  That
 means that instead of just seeing how one quantity depends on another,
 we will see how two quantities could effect a third, or how five
 inputs might cause changes in three outputs.  The very first step of
-this journey is give a convenient mathematical framework for talking
+this journey is to give a convenient mathematical framework for talking
 about lists of numbers.  To that end we define:
 
 \begin{definition}
@@ -119,7 +119,7 @@ The number $n$ is called the dimension of $\R^n$, and $\R^n$ is called $n$-dimen
 
 It becomes quite difficult to visualize high dimensional spaces.  You
 can sometimes visualize a higher dimensional object by having $3$
-spacial dimensions and one color dimension, or $3$ spatial dimensions
+spatial dimensions and one color dimension, or $3$ spatial dimensions
 and one time dimension to get a movie.  Sometimes you can project a
 higher dimensional object into a lower dimensional space.  If you have
 the time, you should watch the \textit{excellent} film

--- a/week1/functions/composition.tex
+++ b/week1/functions/composition.tex
@@ -8,7 +8,7 @@
   One way to build new functions is via ``composition.''
 \end{abstract}
 
-Practically the most important things you can do with functions is to compose them.
+Practically the most important thing you can do with functions is to compose them.
 
 \begin{definition}
   Let $f:A \to B$ and $g:B \to C$.  Then there is another function $(g

--- a/week1/functions/python/higher-order.tex
+++ b/week1/functions/python/higher-order.tex
@@ -36,7 +36,7 @@ def validator():
 
   \begin{solution}
     Write a function \verb|forward_difference| which takes a function $f : \R \to \R$ and returns another real-valued function defined 
-    by $\text{\verb|forward_difference|}(f)(x) = f(x+1)-f(x)$.
+    by $\text{forward_difference}(f)(x) = f(x+1)-f(x)$.
 
     \begin{python}
 def forward_difference(f):

--- a/week1/inner-product/angle.tex
+++ b/week1/inner-product/angle.tex
@@ -38,7 +38,7 @@ Do you remember the law of cosines?  It states the following:
 
 \begin{theorem}
 %	BADBAD PICTURE
-  If a triangle has side lengths $a$,$b$, and $c$, then $c^2 = a^2+b^2 - 2ab\cos(\theta)$, where $\theta$ is the angle opposite the side with length $c$.
+  If a triangle has side lengths $a$, $b$, and $c$, then $c^2 = a^2+b^2 - 2ab\cos(\theta)$, where $\theta$ is the angle opposite the side with length $c$.
 \end{theorem}
 
 Prove the law of cosines.  You may want to read the lovely proof at \href{http://mathproofs.blogspot.com/2006/06/law-of-cosines.html}{mathproofs}.

--- a/week1/inner-product/dot-products.tex
+++ b/week1/inner-product/dot-products.tex
@@ -32,7 +32,7 @@ Prove the following facts about the dot product.  $\vec{u},\vec{v},\vec{w} \in \
 			
 \item $\vec{v}\cdot \vec{v} \geq 0$ (We say that the dot product is ``positive definite'')
 			
-\item if $\vec{v} \cdot z = 0$ for all $z \in \R^n$, then $\vec{v} =\vec{0}$ (The dot product is nondegenerate)
+\item if $\vec{v} \cdot \vec{z} = 0$ for all $\vec{z} \in \R^n$, then $\vec{v} =\vec{0}$ (The dot product is nondegenerate)
 \end{enumerate}
 	
 \begin{free-response}

--- a/week1/linear-maps.tex
+++ b/week1/linear-maps.tex
@@ -489,7 +489,7 @@ We begin by defining linear maps.
   any $\vec{v} \in \R^n$.
   \begin{free-response}
     I want to determine what $L$ does to any vector $\vec{v} = \verticalvector{x_1\\x_2\\x_3\\.\\.\\.\\x_n} \in \R^n$.  
-    I can rewrite $\vec{v}$ as $x_1\vec{e_1}+x_2\vec{e_2}+x_3\vec{e_3}+...+\x_n\vec{e_n}$.  By the linearity of $L$,
+    I can rewrite $\vec{v}$ as $x_1\vec{e_1}+x_2\vec{e_2}+x_3\vec{e_3}+...+x_n\vec{e_n}$.  By the linearity of $L$,
     $L(\vec{v}) = x_1L(\vec{e_1})+x_2L(\vec{e_2})+x_3L(\vec{e_3})+...+x_nL(\vec{e_n})$.  Since I already know the value of 
     $L(\vec{e_i})$ for all $i=1,2,3,...,n$, this allows me to compute $L(\vec{v})$.  So $L$ is completely determined once I know what it does to each of the
     standard basis vectors. 

--- a/week1/linear-maps/python.tex
+++ b/week1/linear-maps/python.tex
@@ -19,7 +19,7 @@
     This was discussed on \url{http://stackoverflow.com/questions/14050824/add-sum-of-values-of-two-lists-into-new-list}{StackOverflow}.
   \end{hint}
 
-  Write a ``vector add'' function.  Your may function assume that the
+  Write a ``vector add'' function.  Your function may assume that the
   two vectors have the same number of entries.
 
 \begin{python}

--- a/week1/tutorial.tex
+++ b/week1/tutorial.tex
@@ -100,7 +100,7 @@ A free response answer type:
 
 Tell us who you are and why you are taking this course!
 \begin{free-response}
-  We are Steven Gubkin and Jim Fowler, and we are writing this course because we loving sharing mathematics with others!
+  We are Steven Gubkin and Jim Fowler, and we are writing this course because we love sharing mathematics with others!
 \end{free-response}
 
 You may have noticed that as you complete activities you get more ``Xudos'' (at the top of the page).  These are points, and people love points.
@@ -115,7 +115,7 @@ You can comment on this page at the very bottom: try it out!
 
 You advance through pages either by completing them and clicking the
 ``next activity'' button, or by navigating on the little side panel to
-the right.  Every time you complete an activity ou get a green check
+the right.  Every time you complete an activity you get a green check
 mark on the side panel, to let you know you have already done it.
  
 Only one more question left:


### PR DESCRIPTION
Fixes typos in week1/tutorial.tex.

Edit: pushed some more commits that fix typos. May have the same fixes as suggested in other PRs.
