### PR TITLE
Replace \texttt{..} with \verb|..|

### DIFF
--- a/week1/functions/python/higher-order.tex
+++ b/week1/functions/python/higher-order.tex
@@ -36,7 +36,7 @@ def validator():
 
   \begin{solution}
     Write a function \verb|forward_difference| which takes a function $f : \R \to \R$ and returns another real-valued function defined 
-    by $\texttt{forward_difference}(f)(x) = f(x+1)-f(x)$.
+    by $\verb|forward_difference|(f)(x) = f(x+1)-f(x)$.
 
     \begin{python}
 def forward_difference(f):


### PR DESCRIPTION
[hrzhu](https://github.com/kisonecat/m2o2c2/commit/6a84abff7ac4312315ab4f68d54763ce5d7c11fa#commitcomment-5768878) points out that MathJax can't parse \texttt{}. I've replaced it with \verb, which MathJax seems able to handle. Tested with `\verb|forward_difference|(f)(x) = f(x+1)-f(x)` [here](http://cdn.mathjax.org/mathjax/latest/test/sample-dynamic.html). Produces the following:

![mathjax_rendering](https://f.cloud.github.com/assets/4433943/2493294/0b65f96c-b28c-11e3-8914-2ef8ec65afa1.png)
