### PR TITLE
vector is written as vertically oriented list according to the course

### DIFF
--- a/week1/linear-maps/matrices.tex
+++ b/week1/linear-maps/matrices.tex
@@ -159,7 +159,7 @@ Let's do another example.
     The dimension of the codomain of $L$ is \answer{3}.
   \end{solution}
   
-  Suppose $\vec{v} = L\left(\verticalvector{0,1}\right)$.  What is $\vec{v}$?
+  Suppose $\vec{v} = L\left(\verticalvector{0\\1}\right)$.  What is $\vec{v}$?
     
   \begin{solution}
   	\begin{hint}


### PR DESCRIPTION
This pull request fixed a typo in week1/linear maps/matrices.
