### PR TITLE
\vec was not slashed

### DIFF
--- a/week3/subspace/kernel.tex
+++ b/week3/subspace/kernel.tex
@@ -73,7 +73,7 @@ Thus $ker(L)$ is a subspace!
 Prove this theorem.
 	
 \begin{free-response}
-	Let $L$ be injective.  Then $L(vec{v}) = \vec{0}$ implies $L(\vec{v}) = L(\vec{0})$.  Since $L$ is injective, this implies $\vec{v} = \vec{0}$.  Thus the only element
+	Let $L$ be injective.  Then $L(\vec{v}) = \vec{0}$ implies $L(\vec{v}) = L(\vec{0})$.  Since $L$ is injective, this implies $\vec{v} = \vec{0}$.  Thus the only element
 	of the kernel is $\vec{0}$.
 	
 	On the other hand, if $ker(L) = \{\vec{0}\}$, then if $L(\vec{v_1}) = L(\vec{v_2})$, then $L(\vec{v_1}-\vec{v_2})= \vec{0}$, so $\vec{v_1}-\vec{v_2}$


### PR DESCRIPTION
\vec was not slashed in the last task model solution
