### PR TITLE
Remove extra "is a bilinear form" in definition of second derivative.

### DIFF
--- a/week5/second-derivative/intuitively.tex
+++ b/week5/second-derivative/intuitively.tex
@@ -44,7 +44,7 @@ Df_{p+\vec{h_2}}(\vec{h_1})  -Df_p(\vec{h_1}) \approx
 With all of this as motivation, we make the following wishy washy "definition"
 
 \begin{definition}
-	The second derivative of a function $f:\R^n \to \R$ is a bilinear form at a point $\mathbf{p}\in \R^n$  
+	The second derivative of a function $f:\R^n \to \R$ at a point $\mathbf{p}\in \R^n$  
 	is a bilinear form $D^2f\big|_\mathbf{p} : \R^n \times \R^n \to \R$ enjoying the following approximation property:
 	
 	\[


### PR DESCRIPTION
Removed extra "is a bilinear form" statement in definition of second derivative.
